### PR TITLE
Add GitHub Actions setting & fix `ocamyul.opam` to install dependecies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+        - main
+
+jobs:
+  build:
+    name: Build & Run example
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest', 'macos-latest' ]
+        ocaml-version:
+          - 4.14.1
+          - 5.1.1
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup OCaml ${{ matrix.ocaml-version }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-version }}
+          dune-cache: ${{ matrix.os != 'macos-latest' }}
+
+      - name: Install solc in Ubuntsu
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          sudo add-apt-repository ppa:ethereum/ethereum
+          sudo apt-get update
+          sudo apt-get install -y solc
+
+      - name: Install solc in macOS
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: |
+          brew tap ethereum/ethereum
+          brew install solidity
+
+      - name: Install dependencies
+        run: opam install . --deps-only --with-doc --verbose
+
+      - name: Build
+        run: opam exec -- dune build
+
+      - name: Run `erc20.ml`
+        run: opam exec -- dune exec ocamyulc sample/src/erc20.ml

--- a/ocamyul.opam
+++ b/ocamyul.opam
@@ -1,4 +1,15 @@
 opam-version: "2.0"
+name: "ocaml2evm"
+version: "1.0.0"
+maintainer: "DMM Web3"
 build: [
   ["dune" "build"]
 ]
+depends: [
+  "yojson" {= "2.1.1"}
+  "digestif" {= "1.1.4"}
+]
+description: """The compiler that:
+  * generates a Yul (https://docs.soliditylang.org/en/latest/yul.html) code from an OCaml code,
+  * passes the compiled result to solc, and
+  * saves the result .json file including an ABI and an EVM code."""


### PR DESCRIPTION
Example Result: https://github.com/y-yu/ocaml2evm/actions/runs/7667397901/job/20897133979?pr=1

```
Run opam exec -- dune exec ocamyulc sample/src/erc20.ml
/bin/sh: 1: solc: not found
Fatal error: exception Yojson__Common.Json_error("Blank input data")
```

Is `solc` not correct? 🤔 I think it should be `solcjs`.